### PR TITLE
Fix pointer placement on uint64_t

### DIFF
--- a/include/openmc/angle_energy.h
+++ b/include/openmc/angle_energy.h
@@ -14,7 +14,7 @@ namespace openmc {
 
 class AngleEnergy {
 public:
-  virtual void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  virtual void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const = 0;
   virtual ~AngleEnergy() = default;
 };

--- a/include/openmc/distribution.h
+++ b/include/openmc/distribution.h
@@ -21,7 +21,7 @@ namespace openmc {
 class Distribution {
 public:
   virtual ~Distribution() = default;
-  virtual double sample(uint64_t * prn_seeds, int stream) const = 0;
+  virtual double sample(uint64_t* prn_seeds, int stream) const = 0;
 };
 
 //==============================================================================
@@ -37,7 +37,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 
   // Properties
   const std::vector<double>& x() const { return x_; }
@@ -63,7 +63,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 private:
   double a_; //!< Lower bound of distribution
   double b_; //!< Upper bound of distribution
@@ -82,7 +82,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 private:
   double theta_; //!< Factor in exponential [eV]
 };
@@ -100,7 +100,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 private:
   double a_; //!< Factor in exponential [eV]
   double b_; //!< Factor in square root [1/eV]
@@ -119,7 +119,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 private:
   double mean_value_;    //!< middle of distribution [eV]
   double std_dev_; //!< standard deviation [eV]
@@ -139,7 +139,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 private:
   // example DT fusion m_rat = 5 (D = 2 + T = 3)
   // ion temp = 20000 eV
@@ -163,7 +163,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 
   // x property
   std::vector<double>& x() { return x_; }
@@ -195,7 +195,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled value
-  double sample(uint64_t * prn_seeds, int stream) const;
+  double sample(uint64_t* prn_seeds, int stream) const;
 private:
   std::vector<double> x_; //! Possible outcomes
 };

--- a/include/openmc/distribution_angle.h
+++ b/include/openmc/distribution_angle.h
@@ -26,7 +26,7 @@ public:
   //! \param[inout] prn_seeds Array of pseudorandom number seeds
   //! \param[in] stream Pseudorandom stream index
   //! \return Cosine of the angle in the range [-1,1]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 
   //! Determine whether angle distribution is empty
   //! \return Whether distribution is empty

--- a/include/openmc/distribution_energy.h
+++ b/include/openmc/distribution_energy.h
@@ -22,7 +22,7 @@ namespace openmc {
 
 class EnergyDistribution {
 public:
-  virtual double sample(double E, uint64_t * prn_seeds, int stream) const = 0;
+  virtual double sample(double E, uint64_t* prn_seeds, int stream) const = 0;
   virtual ~EnergyDistribution() = default;
 };
 
@@ -39,7 +39,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom number genererator seed array
   //! \param[in] stream Pseudorandom number genererator stream index
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 private:
   int primary_flag_; //!< Indicator of whether the photon is a primary or
                      //!< non-primary photon.
@@ -60,7 +60,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom number genererator seed array
   //! \param[in] stream Pseudorandom number genererator stream index
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 private:
   double threshold_; //!< Energy threshold in lab, (A + 1)/A * |Q|
   double mass_ratio_; //!< (A/(A+1))^2
@@ -81,7 +81,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom number genererator seed array
   //! \param[in] stream Pseudorandom number genererator stream index
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 private:
   //! Outgoing energy for a single incoming energy
   struct CTTable {
@@ -112,7 +112,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom number genererator seed array
   //! \param[in] stream Pseudorandom number genererator stream index
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 private:
   Tabulated1D theta_; //!< Incoming energy dependent parameter
   double u_; //!< Restriction energy
@@ -132,7 +132,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom number genererator seed array
   //! \param[in] stream Pseudorandom number genererator stream index
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 private:
   Tabulated1D theta_; //!< Incoming energy dependent parameter
   double u_; //!< Restriction energy
@@ -152,7 +152,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom number genererator seed array
   //! \param[in] stream Pseudorandom number genererator stream index
   //! \return Sampled energy in [eV]
-  double sample(double E, uint64_t * prn_seeds, int stream) const;
+  double sample(double E, uint64_t* prn_seeds, int stream) const;
 private:
   Tabulated1D a_; //!< Energy-dependent 'a' parameter
   Tabulated1D b_; //!< Energy-dependent 'b' parameter

--- a/include/openmc/distribution_multi.h
+++ b/include/openmc/distribution_multi.h
@@ -26,7 +26,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Direction sampled
-  virtual Direction sample(uint64_t * prn_seeds, int stream) const = 0;
+  virtual Direction sample(uint64_t* prn_seeds, int stream) const = 0;
 
   Direction u_ref_ {0.0, 0.0, 1.0};  //!< reference direction
 };
@@ -44,7 +44,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Direction sampled
-  Direction sample(uint64_t * prn_seeds, int stream) const;
+  Direction sample(uint64_t* prn_seeds, int stream) const;
 private:
   UPtrDist mu_;  //!< Distribution of polar angle
   UPtrDist phi_; //!< Distribution of azimuthal angle
@@ -62,7 +62,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled direction
-  Direction sample(uint64_t * prn_seeds, int stream) const;
+  Direction sample(uint64_t* prn_seeds, int stream) const;
 };
 
 //==============================================================================
@@ -78,7 +78,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled direction
-  Direction sample(uint64_t * prn_seeds, int stream) const;
+  Direction sample(uint64_t* prn_seeds, int stream) const;
 };
 
 using UPtrAngle = std::unique_ptr<UnitSphereDistribution>;

--- a/include/openmc/distribution_spatial.h
+++ b/include/openmc/distribution_spatial.h
@@ -17,7 +17,7 @@ public:
   virtual ~SpatialDistribution() = default;
 
   //! Sample a position from the distribution
-  virtual Position sample(uint64_t * prn_seeds, int stream) const = 0;
+  virtual Position sample(uint64_t* prn_seeds, int stream) const = 0;
 };
 
 //==============================================================================
@@ -32,7 +32,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled position
-  Position sample(uint64_t * prn_seeds, int stream) const;
+  Position sample(uint64_t* prn_seeds, int stream) const;
 private:
   UPtrDist x_; //!< Distribution of x coordinates
   UPtrDist y_; //!< Distribution of y coordinates
@@ -51,7 +51,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled position
-  Position sample(uint64_t * prn_seeds, int stream) const;
+  Position sample(uint64_t* prn_seeds, int stream) const;
 private:
   UPtrDist r_; //!< Distribution of r coordinates
   UPtrDist theta_; //!< Distribution of theta coordinates
@@ -71,7 +71,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled position
-  Position sample(uint64_t * prn_seeds, int stream) const;
+  Position sample(uint64_t* prn_seeds, int stream) const;
 
   // Properties
   bool only_fissionable() const { return only_fissionable_; }
@@ -95,7 +95,7 @@ public:
   //! \param prn_seeds Array of pseudorandom number seeds
   //! \param stream Pseudorandom stream index
   //! \return Sampled position
-  Position sample(uint64_t * prn_seeds, int stream) const;
+  Position sample(uint64_t* prn_seeds, int stream) const;
 private:
   Position r_; //!< Single position at which sites are generated
 };

--- a/include/openmc/math_functions.h
+++ b/include/openmc/math_functions.h
@@ -134,10 +134,10 @@ extern "C" void calc_zn_rad(int n, double rho, double zn_rad[]);
 //==============================================================================
 
 extern "C" void rotate_angle_c(double uvw[3], double mu, const double* phi,
-  uint64_t * prn_seeds, int stream);
+  uint64_t* prn_seeds, int stream);
 
 Direction rotate_angle(Direction u, double mu, const double* phi,
-  uint64_t * prn_streams, int stream);
+  uint64_t* prn_streams, int stream);
 
 //==============================================================================
 //! Samples an energy from the Maxwell fission distribution based on a direct
@@ -153,7 +153,7 @@ Direction rotate_angle(Direction u, double mu, const double* phi,
 //! \return The sampled outgoing energy
 //==============================================================================
 
-extern "C" double maxwell_spectrum(double T, uint64_t * prn_seeds, int stream);
+extern "C" double maxwell_spectrum(double T, uint64_t* prn_seeds, int stream);
 
 //==============================================================================
 //! Samples an energy from a Watt energy-dependent fission distribution.
@@ -170,7 +170,7 @@ extern "C" double maxwell_spectrum(double T, uint64_t * prn_seeds, int stream);
 //! \return The sampled outgoing energy
 //==============================================================================
 
-extern "C" double watt_spectrum(double a, double b, uint64_t * prn_seeds, int stream);
+extern "C" double watt_spectrum(double a, double b, uint64_t* prn_seeds, int stream);
 
 //==============================================================================
 //! Samples an energy from the Gaussian energy-dependent fission distribution.
@@ -188,7 +188,7 @@ extern "C" double watt_spectrum(double a, double b, uint64_t * prn_seeds, int st
 //! @result The sampled outgoing energy
 //==============================================================================
 
-extern "C" double normal_variate(double mean, double std_dev, uint64_t * prn_seeds,
+extern "C" double normal_variate(double mean, double std_dev, uint64_t* prn_seeds,
   int stream);
 
 //==============================================================================
@@ -207,7 +207,7 @@ extern "C" double normal_variate(double mean, double std_dev, uint64_t * prn_see
 //==============================================================================
 
 extern "C" double muir_spectrum(double e0, double m_rat, double kt,
-  uint64_t * prn_seeds, int stream);
+  uint64_t* prn_seeds, int stream);
 
 //==============================================================================
 //! Doppler broadens the windowed multipole curvefit.

--- a/include/openmc/mgxs.h
+++ b/include/openmc/mgxs.h
@@ -157,7 +157,7 @@ class Mgxs {
     //! @param prn_seeds Pseudorandom seed array.
     //! @param stream Pseudorandom stream index.
     void
-    sample_fission_energy(int gin, int& dg, int& gout, uint64_t * prn_seeds, int stream);
+    sample_fission_energy(int gin, int& dg, int& gout, uint64_t* prn_seeds, int stream);
 
     //! \brief Samples the outgoing energy and angle from a scatter event.
     //!
@@ -168,7 +168,7 @@ class Mgxs {
     //! @param prn_seeds Array of pseudorandom stream seeds
 	//! @param stream Pseudorandom stream index
     void
-    sample_scatter(int gin, int& gout, double& mu, double& wgt, uint64_t * prn_seeds,
+    sample_scatter(int gin, int& gout, double& mu, double& wgt, uint64_t* prn_seeds,
       int stream);
 
     //! \brief Calculates cross section quantities needed for tracking.

--- a/include/openmc/photon.h
+++ b/include/openmc/photon.h
@@ -45,12 +45,12 @@ public:
   void calculate_xs(Particle& p) const;
 
   void compton_scatter(double alpha, bool doppler, double* alpha_out,
-    double* mu, int* i_shell, uint64_t * prn_seeds, int stream) const;
+    double* mu, int* i_shell, uint64_t* prn_seeds, int stream) const;
 
-  double rayleigh_scatter(double alpha, uint64_t * prn_seeds, int stream) const;
+  double rayleigh_scatter(double alpha, uint64_t* prn_seeds, int stream) const;
 
   void pair_production(double alpha, double* E_electron, double* E_positron,
-    double* mu_electron, double* mu_positron, uint64_t * prn_seeds, int stream) const;
+    double* mu_electron, double* mu_positron, uint64_t* prn_seeds, int stream) const;
 
   void atomic_relaxation(const ElectronSubshell& shell, Particle& p) const;
 
@@ -97,14 +97,14 @@ public:
 
 private:
   void compton_doppler(double alpha, double mu, double* E_out, int* i_shell,
-                       uint64_t * prn_seeds, int stream) const;
+                       uint64_t* prn_seeds, int stream) const;
 };
 
 //==============================================================================
 // Non-member functions
 //==============================================================================
 
-std::pair<double, double> klein_nishina(double alpha, uint64_t * prn_seeds, int stream);
+std::pair<double, double> klein_nishina(double alpha, uint64_t* prn_seeds, int stream);
 
 void free_memory_photon();
 

--- a/include/openmc/physics.h
+++ b/include/openmc/physics.h
@@ -72,17 +72,17 @@ void sab_scatter(int i_nuclide, int i_sab, Particle* p);
 //! dependence of cross sections in treating resonance elastic scattering such
 //! as the DBRC and a new, accelerated scheme are also implemented here.
 Direction sample_target_velocity(const Nuclide* nuc, double E, Direction u,
-   Direction v_neut, double xs_eff, double kT, uint64_t * prn_seeds, int stream);
+   Direction v_neut, double xs_eff, double kT, uint64_t* prn_seeds, int stream);
 
 //! samples a target velocity based on the free gas scattering formulation, used
 //! by most Monte Carlo codes, in which cross section is assumed to be constant
 //! in energy. Excellent documentation for this method can be found in
 //! FRA-TM-123.
 Direction sample_cxs_target_velocity(double awr, double E, Direction u, double kT,
-		uint64_t * prn_seeds, int stream);
+		uint64_t* prn_seeds, int stream);
 
 void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in,
-  Particle::Bank* site, uint64_t * prn_seeds, int stream);
+  Particle::Bank* site, uint64_t* prn_seeds, int stream);
 
 //! handles all reactions with a single secondary neutron (other than fission),
 //! i.e. level scattering, (n,np), (n,na), etc.

--- a/include/openmc/random_lcg.h
+++ b/include/openmc/random_lcg.h
@@ -26,7 +26,7 @@ constexpr int64_t DEFAULT_SEED = 1;
 //! @return A random number between 0 and 1
 //==============================================================================
 
-extern "C" double prn(uint64_t * seeds, int stream);
+extern "C" double prn(uint64_t* seeds, int stream);
 
 //==============================================================================
 //! Generate a random number which is 'n' times ahead from the current seed.
@@ -39,7 +39,7 @@ extern "C" double prn(uint64_t * seeds, int stream);
 //! @return A random number between 0 and 1
 //==============================================================================
 
-extern "C" double future_prn(int64_t n, uint64_t * prn_seeds, int stream);
+extern "C" double future_prn(int64_t n, uint64_t* prn_seeds, int stream);
 
 //==============================================================================
 //! Set the RNG seeds to unique values based on the ID of the particle.
@@ -47,7 +47,7 @@ extern "C" double future_prn(int64_t n, uint64_t * prn_seeds, int stream);
 //! @param id The particle ID
 //==============================================================================
 
-extern "C" void set_particle_seed(int64_t id, uint64_t * prn_seeds );
+extern "C" void set_particle_seed(int64_t id, uint64_t* prn_seeds );
 
 //==============================================================================
 //! Advance the random number seed 'n' times from the current seed.
@@ -56,7 +56,7 @@ extern "C" void set_particle_seed(int64_t id, uint64_t * prn_seeds );
 //! @param n The number of RNG seeds to skip ahead by
 //==============================================================================
 
-extern "C" void advance_prn_seed(int64_t n, uint64_t * prn_seeds, int stream);
+extern "C" void advance_prn_seed(int64_t n, uint64_t* prn_seeds, int stream);
 
 //==============================================================================
 //! Advance a random number seed 'n' times.

--- a/include/openmc/reaction_product.h
+++ b/include/openmc/reaction_product.h
@@ -44,7 +44,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Pseudorandom array of stream seeds
   //! \param[in] stream Psuedorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const;
 
   Particle::Type particle_; //!< Particle type

--- a/include/openmc/scattdata.h
+++ b/include/openmc/scattdata.h
@@ -68,7 +68,7 @@ class ScattData {
     //! @param prn_seeds Array of pseudorandom stream seeds
 	//! @param stream Pseudorandom stream index
     virtual void
-    sample(int gin, int& gout, double& mu, double& wgt, uint64_t * prn_seeds,
+    sample(int gin, int& gout, double& mu, double& wgt, uint64_t* prn_seeds,
       int stream) = 0;
 
     //! \brief Initializes the ScattData object from a given scatter and
@@ -115,7 +115,7 @@ class ScattData {
     //! @param prn_seeds Array of pseudorandom stream seeds
 	//! @param stream Pseudorandom stream index
     void
-    sample_energy(int gin, int& gout, int& i_gout, uint64_t * prn_seeds, int stream);
+    sample_energy(int gin, int& gout, int& i_gout, uint64_t* prn_seeds, int stream);
 
     //! \brief Provides a cross section value given certain parameters
     //!
@@ -166,7 +166,7 @@ class ScattDataLegendre: public ScattData {
     calc_f(int gin, int gout, double mu);
 
     void
-    sample(int gin, int& gout, double& mu, double& wgt, uint64_t * prn_seeds, int stream);
+    sample(int gin, int& gout, double& mu, double& wgt, uint64_t* prn_seeds, int stream);
 
     size_t
     get_order() {return dist[0][0].size() - 1;};
@@ -202,7 +202,7 @@ class ScattDataHistogram: public ScattData {
     calc_f(int gin, int gout, double mu);
 
     void
-    sample(int gin, int& gout, double& mu, double& wgt, uint64_t * prn_seeds, int stream);
+    sample(int gin, int& gout, double& mu, double& wgt, uint64_t* prn_seeds, int stream);
 
     size_t
     get_order() {return dist[0][0].size();};
@@ -243,7 +243,7 @@ class ScattDataTabular: public ScattData {
     calc_f(int gin, int gout, double mu);
 
     void
-    sample(int gin, int& gout, double& mu, double& wgt, uint64_t * prn_seeds, int stream);
+    sample(int gin, int& gout, double& mu, double& wgt, uint64_t* prn_seeds, int stream);
 
     size_t
     get_order() {return dist[0][0].size();};

--- a/include/openmc/secondary_correlated.h
+++ b/include/openmc/secondary_correlated.h
@@ -40,7 +40,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
 		  int stream) const override;
 
   // energy property

--- a/include/openmc/secondary_kalbach.h
+++ b/include/openmc/secondary_kalbach.h
@@ -31,7 +31,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Pseudorandom stream seed array
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
 		  int sample) const override;
 private:
   //! Outgoing energy/angle at a single incoming energy

--- a/include/openmc/secondary_nbody.h
+++ b/include/openmc/secondary_nbody.h
@@ -26,7 +26,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
   int stream) const override;
 private:
   int n_bodies_; //!< Number of particles distributed

--- a/include/openmc/secondary_thermal.h
+++ b/include/openmc/secondary_thermal.h
@@ -33,7 +33,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const override;
 private:
   const CoherentElasticXS& xs_; //!< Coherent elastic scattering cross section
@@ -56,7 +56,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const override;
 private:
   double debye_waller_;
@@ -80,7 +80,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const override;
 private:
   const std::vector<double>& energy_; //!< Energies at which cosines are tabulated
@@ -105,7 +105,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const override;
 private:
   const std::vector<double>& energy_; //!< Incident energies
@@ -131,7 +131,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const override;
 private:
   //! Secondary energy/angle distribution

--- a/include/openmc/secondary_uncorrelated.h
+++ b/include/openmc/secondary_uncorrelated.h
@@ -31,7 +31,7 @@ public:
   //! \param[out] mu Outgoing cosine with respect to current direction
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
-  void sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+  void sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
     int stream) const override;
 
   // Accessors

--- a/include/openmc/source.h
+++ b/include/openmc/source.h
@@ -41,7 +41,7 @@ public:
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
   //! \return Sampled site
-  Particle::Bank sample(uint64_t * prn_seed, int stream) const;
+  Particle::Bank sample(uint64_t* prn_seed, int stream) const;
 
   // Properties
   double strength() const { return strength_; }
@@ -64,7 +64,7 @@ extern "C" void initialize_source();
 //! source strength
 //! \param[inout] prn_seeds Array of pseudorandom seeds
 //! \return Sampled source site
-Particle::Bank sample_external_source(uint64_t * prn_seeds);
+Particle::Bank sample_external_source(uint64_t* prn_seeds);
 
 //! Fill source bank at end of generation for fixed source simulations
 void fill_source_bank_fixedsource();

--- a/include/openmc/surface.h
+++ b/include/openmc/surface.h
@@ -116,7 +116,7 @@ public:
   //! \return Outgoing direction of the ray
   virtual Direction reflect(Position r, Direction u) const;
 
-  virtual Direction diffuse_reflect(Position r, Direction u, uint64_t * prn_seeds,
+  virtual Direction diffuse_reflect(Position r, Direction u, uint64_t* prn_seeds,
     int stream) const;
 
   //! Evaluate the equation describing the surface.

--- a/include/openmc/thermal.h
+++ b/include/openmc/thermal.h
@@ -67,7 +67,7 @@ public:
   //! \param[inout] prn_seeds Pseudorandom seed array
   //! \param[in] stream Pseudorandom stream index
   void sample(const NuclideMicroXS& micro_xs, double E_in,
-              double* E_out, double* mu, uint64_t * prn_seeds, int stream);
+              double* E_out, double* mu, uint64_t* prn_seeds, int stream);
 private:
   struct Reaction {
     // Default constructor
@@ -105,7 +105,7 @@ public:
   //! \param[inout] prn_seeds Array of pseudorandom seeds
   //! \param[in] stream Pseudorandom stream index
   void calculate_xs(double E, double sqrtkT, int* i_temp, double* elastic,
-                    double* inelastic, uint64_t * prn_seeds, int stream) const;
+                    double* inelastic, uint64_t* prn_seeds, int stream) const;
 
   //! Determine whether table applies to a particular nuclide
   //!

--- a/src/distribution.cpp
+++ b/src/distribution.cpp
@@ -35,7 +35,7 @@ Discrete::Discrete(const double* x, const double* p, int n)
   normalize();
 }
 
-double Discrete::sample(uint64_t * prn_seeds, int stream) const
+double Discrete::sample(uint64_t* prn_seeds, int stream) const
 {
   int n = x_.size();
   if (n > 1) {
@@ -74,7 +74,7 @@ Uniform::Uniform(pugi::xml_node node)
   b_ = params.at(1);
 }
 
-double Uniform::sample(uint64_t * prn_seeds, int stream) const
+double Uniform::sample(uint64_t* prn_seeds, int stream) const
 {
   return a_ + prn(prn_seeds, stream)*(b_ - a_);
 }
@@ -88,7 +88,7 @@ Maxwell::Maxwell(pugi::xml_node node)
   theta_ = std::stod(get_node_value(node, "parameters"));
 }
 
-double Maxwell::sample(uint64_t * prn_seeds, int stream) const
+double Maxwell::sample(uint64_t* prn_seeds, int stream) const
 {
   return maxwell_spectrum(theta_, prn_seeds, stream);
 }
@@ -108,7 +108,7 @@ Watt::Watt(pugi::xml_node node)
   b_ = params.at(1);
 }
 
-double Watt::sample(uint64_t * prn_seeds, int stream) const
+double Watt::sample(uint64_t* prn_seeds, int stream) const
 {
   return watt_spectrum(a_, b_, prn_seeds, stream);
 }
@@ -116,7 +116,7 @@ double Watt::sample(uint64_t * prn_seeds, int stream) const
 //==============================================================================
 // Normal implementation
 //==============================================================================
-Normal::Normal(pugi::xml_node node) 
+Normal::Normal(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node,"parameters");
   if (params.size() != 2)
@@ -127,7 +127,7 @@ Normal::Normal(pugi::xml_node node)
   std_dev_ = params.at(1);
 }
 
-double Normal::sample(uint64_t * prn_seeds, int stream) const
+double Normal::sample(uint64_t* prn_seeds, int stream) const
 {
   return normal_variate(mean_value_, std_dev_, prn_seeds, stream);
 }
@@ -135,7 +135,7 @@ double Normal::sample(uint64_t * prn_seeds, int stream) const
 //==============================================================================
 // Muir implementation
 //==============================================================================
-Muir::Muir(pugi::xml_node node) 
+Muir::Muir(pugi::xml_node node)
 {
   auto params = get_node_array<double>(node,"parameters");
   if (params.size() != 3)
@@ -147,7 +147,7 @@ Muir::Muir(pugi::xml_node node)
   kt_ = params.at(2);
 }
 
-double Muir::sample(uint64_t * prn_seeds, int stream) const
+double Muir::sample(uint64_t* prn_seeds, int stream) const
 {
   return muir_spectrum(e0_, m_rat_, kt_, prn_seeds, stream);
 }
@@ -220,7 +220,7 @@ void Tabular::init(const double* x, const double* p, std::size_t n, const double
   }
 }
 
-double Tabular::sample(uint64_t * prn_seeds, int stream) const
+double Tabular::sample(uint64_t* prn_seeds, int stream) const
 {
   // Sample value of CDF
   double c = prn(prn_seeds, stream);
@@ -263,7 +263,7 @@ double Tabular::sample(uint64_t * prn_seeds, int stream) const
 // Equiprobable implementation
 //==============================================================================
 
-double Equiprobable::sample(uint64_t * prn_seeds, int stream) const
+double Equiprobable::sample(uint64_t* prn_seeds, int stream) const
 {
   std::size_t n = x_.size();
 

--- a/src/distribution_angle.cpp
+++ b/src/distribution_angle.cpp
@@ -62,7 +62,7 @@ AngleDistribution::AngleDistribution(hid_t group)
   }
 }
 
-double AngleDistribution::sample(double E, uint64_t * prn_seeds, int stream) const
+double AngleDistribution::sample(double E, uint64_t* prn_seeds, int stream) const
 {
   // Determine number of incoming energies
   auto n = energy_.size();

--- a/src/distribution_energy.cpp
+++ b/src/distribution_energy.cpp
@@ -25,7 +25,7 @@ DiscretePhoton::DiscretePhoton(hid_t group)
   read_attribute(group, "atomic_weight_ratio", A_);
 }
 
-double DiscretePhoton::sample(double E, uint64_t * prn_seeds, int stream) const
+double DiscretePhoton::sample(double E, uint64_t* prn_seeds, int stream) const
 {
   if (primary_flag_ == 2) {
     return energy_ + A_/(A_+ 1)*E;
@@ -44,7 +44,7 @@ LevelInelastic::LevelInelastic(hid_t group)
   read_attribute(group, "mass_ratio", mass_ratio_);
 }
 
-double LevelInelastic::sample(double E, uint64_t * prn_seeds, int stream ) const
+double LevelInelastic::sample(double E, uint64_t* prn_seeds, int stream ) const
 {
   return mass_ratio_*(E - threshold_);
 }
@@ -146,7 +146,7 @@ ContinuousTabular::ContinuousTabular(hid_t group)
   } // incoming energies
 }
 
-double ContinuousTabular::sample(double E, uint64_t * prn_seeds, int stream) const
+double ContinuousTabular::sample(double E, uint64_t* prn_seeds, int stream) const
 {
   // Read number of interpolation regions and incoming energies
   bool histogram_interp;
@@ -275,7 +275,7 @@ MaxwellEnergy::MaxwellEnergy(hid_t group)
   close_dataset(dset);
 }
 
-double MaxwellEnergy::sample(double E, uint64_t * prn_seeds, int stream) const
+double MaxwellEnergy::sample(double E, uint64_t* prn_seeds, int stream) const
 {
   // Get temperature corresponding to incoming energy
   double theta = theta_(E);
@@ -301,7 +301,7 @@ Evaporation::Evaporation(hid_t group)
   close_dataset(dset);
 }
 
-double Evaporation::sample(double E, uint64_t * prn_seeds, int stream) const
+double Evaporation::sample(double E, uint64_t* prn_seeds, int stream) const
 {
   // Get temperature corresponding to incoming energy
   double theta = theta_(E);
@@ -338,7 +338,7 @@ WattEnergy::WattEnergy(hid_t group)
   close_dataset(dset);
 }
 
-double WattEnergy::sample(double E, uint64_t * prn_seeds, int stream) const
+double WattEnergy::sample(double E, uint64_t* prn_seeds, int stream) const
 {
   // Determine Watt parameters at incident energy
   double a = a_(E);

--- a/src/distribution_multi.cpp
+++ b/src/distribution_multi.cpp
@@ -53,7 +53,7 @@ PolarAzimuthal::PolarAzimuthal(pugi::xml_node node)
   }
 }
 
-Direction PolarAzimuthal::sample(uint64_t * prn_seeds, int stream) const
+Direction PolarAzimuthal::sample(uint64_t* prn_seeds, int stream) const
 {
   // Sample cosine of polar angle
   double mu = mu_->sample(prn_seeds, stream);
@@ -74,7 +74,7 @@ Direction PolarAzimuthal::sample(uint64_t * prn_seeds, int stream) const
 // Isotropic implementation
 //==============================================================================
 
-Direction Isotropic::sample(uint64_t * prn_seeds, int stream) const
+Direction Isotropic::sample(uint64_t* prn_seeds, int stream) const
 {
   double phi = 2.0*PI*prn(prn_seeds, stream);
   double mu = 2.0*prn(prn_seeds, stream) - 1.0;
@@ -86,7 +86,7 @@ Direction Isotropic::sample(uint64_t * prn_seeds, int stream) const
 // Monodirectional implementation
 //==============================================================================
 
-Direction Monodirectional::sample(uint64_t * prn_seeds, int stream) const
+Direction Monodirectional::sample(uint64_t* prn_seeds, int stream) const
 {
   return u_ref_;
 }

--- a/src/distribution_spatial.cpp
+++ b/src/distribution_spatial.cpp
@@ -46,7 +46,7 @@ CartesianIndependent::CartesianIndependent(pugi::xml_node node)
   }
 }
 
-Position CartesianIndependent::sample(uint64_t * prn_seeds, int stream) const
+Position CartesianIndependent::sample(uint64_t* prn_seeds, int stream) const
 {
   return {x_->sample(prn_seeds, stream), y_->sample(prn_seeds, stream), z_->sample(prn_seeds, stream)};
 }
@@ -107,7 +107,7 @@ SphericalIndependent::SphericalIndependent(pugi::xml_node node)
 
 }
 
-Position SphericalIndependent::sample(uint64_t * prn_seeds, int stream) const
+Position SphericalIndependent::sample(uint64_t* prn_seeds, int stream) const
 {
   double r = r_->sample(prn_seeds, stream);
   double theta = theta_->sample(prn_seeds, stream);
@@ -135,7 +135,7 @@ SpatialBox::SpatialBox(pugi::xml_node node, bool fission)
   upper_right_ = Position{params[3], params[4], params[5]};
 }
 
-Position SpatialBox::sample(uint64_t * prn_seeds, int stream) const
+Position SpatialBox::sample(uint64_t* prn_seeds, int stream) const
 {
   Position xi {prn(prn_seeds, stream), prn(prn_seeds, stream), prn(prn_seeds, stream)};
   return lower_left_ + xi*(upper_right_ - lower_left_);
@@ -157,7 +157,7 @@ SpatialPoint::SpatialPoint(pugi::xml_node node)
   r_ = Position{params.data()};
 }
 
-Position SpatialPoint::sample(uint64_t * prn_seeds, int stream) const
+Position SpatialPoint::sample(uint64_t* prn_seeds, int stream) const
 {
   return r_;
 }

--- a/src/math_functions.cpp
+++ b/src/math_functions.cpp
@@ -630,7 +630,7 @@ void calc_zn_rad(int n, double rho, double zn_rad[]) {
 }
 
 
-void rotate_angle_c(double uvw[3], double mu, const double* phi, uint64_t * prn_seeds, int stream) {
+void rotate_angle_c(double uvw[3], double mu, const double* phi, uint64_t* prn_seeds, int stream) {
   Direction u = rotate_angle({uvw}, mu, phi, prn_seeds, stream);
   uvw[0] = u.x;
   uvw[1] = u.y;
@@ -638,7 +638,7 @@ void rotate_angle_c(double uvw[3], double mu, const double* phi, uint64_t * prn_
 }
 
 
-Direction rotate_angle(Direction u, double mu, const double* phi, uint64_t * prn_seeds, int stream)
+Direction rotate_angle(Direction u, double mu, const double* phi, uint64_t* prn_seeds, int stream)
 {
   // Sample azimuthal angle in [0,2pi) if none provided
   double phi_;
@@ -675,7 +675,7 @@ Direction rotate_angle(Direction u, double mu, const double* phi, uint64_t * prn
 }
 
 
-double maxwell_spectrum(double T, uint64_t * prn_seeds, int stream) {
+double maxwell_spectrum(double T, uint64_t* prn_seeds, int stream) {
   // Set the random numbers
   double r1 = prn(prn_seeds, stream);
   double r2 = prn(prn_seeds, stream);
@@ -691,7 +691,7 @@ double maxwell_spectrum(double T, uint64_t * prn_seeds, int stream) {
 }
 
 
-double normal_variate(double mean, double standard_deviation, uint64_t * prn_seeds, int stream) {
+double normal_variate(double mean, double standard_deviation, uint64_t* prn_seeds, int stream) {
   // perhaps there should be a limit to the number of resamples
   while ( true ) {
     double v1 = 2 * prn(prn_seeds, stream) - 1.;
@@ -707,7 +707,7 @@ double normal_variate(double mean, double standard_deviation, uint64_t * prn_see
   }
 }
 
-double muir_spectrum(double e0, double m_rat, double kt, uint64_t * prn_seeds, int stream) {
+double muir_spectrum(double e0, double m_rat, double kt, uint64_t* prn_seeds, int stream) {
   // note sigma here is a factor of 2 shy of equation
   // 8 in https://permalink.lanl.gov/object/tr?what=info:lanl-repo/lareport/LA-05411-MS
   double sigma = std::sqrt(2.*e0*kt/m_rat);
@@ -715,7 +715,7 @@ double muir_spectrum(double e0, double m_rat, double kt, uint64_t * prn_seeds, i
 }
 
 
-double watt_spectrum(double a, double b, uint64_t * prn_seeds, int stream) {
+double watt_spectrum(double a, double b, uint64_t* prn_seeds, int stream) {
   double w = maxwell_spectrum(a, prn_seeds, stream);
   double E_out = w + 0.25 * a * a * b + (2. * prn(prn_seeds, stream) - 1.) * std::sqrt(a * a * b * w);
 

--- a/src/mgxs.cpp
+++ b/src/mgxs.cpp
@@ -529,7 +529,7 @@ Mgxs::get_xs(int xstype, int gin, const int* gout, const double* mu,
 //==============================================================================
 
 void
-Mgxs::sample_fission_energy(int gin, int& dg, int& gout, uint64_t * prn_seeds, int stream)
+Mgxs::sample_fission_energy(int gin, int& dg, int& gout, uint64_t* prn_seeds, int stream)
 {
   // This method assumes that the temperature and angle indices are set
 #ifdef _OPENMP
@@ -585,7 +585,7 @@ Mgxs::sample_fission_energy(int gin, int& dg, int& gout, uint64_t * prn_seeds, i
 //==============================================================================
 
 void
-Mgxs::sample_scatter(int gin, int& gout, double& mu, double& wgt, uint64_t * prn_seeds,
+Mgxs::sample_scatter(int gin, int& gout, double& mu, double& wgt, uint64_t* prn_seeds,
   int stream)
 {
   // This method assumes that the temperature and angle indices are set

--- a/src/photon.cpp
+++ b/src/photon.cpp
@@ -290,7 +290,7 @@ PhotonInteraction::PhotonInteraction(hid_t group, int i_element)
 }
 
 void PhotonInteraction::compton_scatter(double alpha, bool doppler,
-  double* alpha_out, double* mu, int* i_shell, uint64_t * prn_seeds, int stream) const
+  double* alpha_out, double* mu, int* i_shell, uint64_t* prn_seeds, int stream) const
 {
   double form_factor_xmax = 0.0;
   while (true) {
@@ -323,7 +323,7 @@ void PhotonInteraction::compton_scatter(double alpha, bool doppler,
 }
 
 void PhotonInteraction::compton_doppler(double alpha, double mu,
-  double* E_out, int* i_shell, uint64_t * prn_seeds, int stream) const
+  double* E_out, int* i_shell, uint64_t* prn_seeds, int stream) const
 {
   auto n = data::compton_profile_pz.size();
 
@@ -496,7 +496,7 @@ void PhotonInteraction::calculate_xs(Particle& p) const
   xs.last_E = p.E_;
 }
 
-double PhotonInteraction::rayleigh_scatter(double alpha, uint64_t * prn_seeds, int stream) const
+double PhotonInteraction::rayleigh_scatter(double alpha, uint64_t* prn_seeds, int stream) const
 {
   double mu;
   while (true) {
@@ -525,7 +525,7 @@ double PhotonInteraction::rayleigh_scatter(double alpha, uint64_t * prn_seeds, i
 }
 
 void PhotonInteraction::pair_production(double alpha, double* E_electron,
-  double* E_positron, double* mu_electron, double* mu_positron, uint64_t * prn_seeds,
+  double* E_positron, double* mu_electron, double* mu_positron, uint64_t* prn_seeds,
   int stream) const
 {
   constexpr double r[] {
@@ -711,7 +711,7 @@ void PhotonInteraction::atomic_relaxation(const ElectronSubshell& shell, Particl
 // Non-member functions
 //==============================================================================
 
-std::pair<double, double> klein_nishina(double alpha, uint64_t * prn_seeds, int stream)
+std::pair<double, double> klein_nishina(double alpha, uint64_t* prn_seeds, int stream)
 {
   double alpha_out, mu;
   double beta = 1.0 + 2.0*alpha;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -750,7 +750,7 @@ void sab_scatter(int i_nuclide, int i_sab, Particle* p)
 }
 
 Direction sample_target_velocity(const Nuclide* nuc, double E, Direction u,
-  Direction v_neut, double xs_eff, double kT, uint64_t * prn_seeds, int stream)
+  Direction v_neut, double xs_eff, double kT, uint64_t* prn_seeds, int stream)
 {
   // check if nuclide is a resonant scatterer
   ResScatMethod sampling_method;
@@ -901,7 +901,7 @@ Direction sample_target_velocity(const Nuclide* nuc, double E, Direction u,
 }
 
 Direction
-sample_cxs_target_velocity(double awr, double E, Direction u, double kT, uint64_t * prn_seeds, int stream)
+sample_cxs_target_velocity(double awr, double E, Direction u, double kT, uint64_t* prn_seeds, int stream)
 {
   double beta_vn = std::sqrt(awr * E / kT);
   double alpha = 1.0/(1.0 + std::sqrt(PI)*beta_vn/2.0);
@@ -951,7 +951,7 @@ sample_cxs_target_velocity(double awr, double E, Direction u, double kT, uint64_
   return vt * rotate_angle(u, mu, nullptr, prn_seeds, stream);
 }
 
-void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in, Particle::Bank* site, uint64_t * prn_seeds, int stream)
+void sample_fission_neutron(int i_nuclide, const Reaction* rx, double E_in, Particle::Bank* site, uint64_t* prn_seeds, int stream)
 {
   // Sample cosine of angle -- fission neutrons are always emitted
   // isotropically. Sometimes in ACE data, fission reactions actually have

--- a/src/random_lcg.cpp
+++ b/src/random_lcg.cpp
@@ -32,7 +32,7 @@ constexpr double   prn_norm   {1.0 / prn_mod};           // 2^-63
 //==============================================================================
 
 extern "C" double
-prn(uint64_t * prn_seeds, int stream)
+prn(uint64_t* prn_seeds, int stream)
 {
   // This algorithm uses bit-masking to find the next integer(8) value to be
   // used to calculate the random number.
@@ -48,7 +48,7 @@ prn(uint64_t * prn_seeds, int stream)
 //==============================================================================
 
 extern "C" double
-future_prn(int64_t n, uint64_t * prn_seeds, int stream)
+future_prn(int64_t n, uint64_t* prn_seeds, int stream)
 {
   return future_seed(static_cast<uint64_t>(n), prn_seeds[stream]) * prn_norm;
 }
@@ -58,7 +58,7 @@ future_prn(int64_t n, uint64_t * prn_seeds, int stream)
 //==============================================================================
 
 extern "C" void
-set_particle_seed(int64_t id, uint64_t * prn_seeds)
+set_particle_seed(int64_t id, uint64_t* prn_seeds)
 {
   for (int i = 0; i < N_STREAMS; i++) {
     prn_seeds[i] = future_seed(static_cast<uint64_t>(id) * prn_stride, master_seed + i);
@@ -70,7 +70,7 @@ set_particle_seed(int64_t id, uint64_t * prn_seeds)
 //==============================================================================
 
 extern "C" void
-advance_prn_seed(int64_t n, uint64_t * prn_seeds, int stream)
+advance_prn_seed(int64_t n, uint64_t* prn_seeds, int stream)
 {
   prn_seeds[stream] = future_seed(static_cast<uint64_t>(n), prn_seeds[stream]);
 }

--- a/src/reaction_product.cpp
+++ b/src/reaction_product.cpp
@@ -77,7 +77,7 @@ ReactionProduct::ReactionProduct(hid_t group)
 }
 
 void ReactionProduct::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   auto n = applicability_.size();
   if (n > 1) {

--- a/src/scattdata.cpp
+++ b/src/scattdata.cpp
@@ -167,7 +167,7 @@ ScattData::base_combine(size_t max_order,
 //==============================================================================
 
 void
-ScattData::sample_energy(int gin, int& gout, int& i_gout, uint64_t * prn_seeds, int stream)
+ScattData::sample_energy(int gin, int& gout, int& i_gout, uint64_t* prn_seeds, int stream)
 {
   // Sample the outgoing group
   double xi = prn(prn_seeds, stream);
@@ -348,7 +348,7 @@ ScattDataLegendre::calc_f(int gin, int gout, double mu)
 
 void
 ScattDataLegendre::sample(int gin, int& gout, double& mu, double& wgt,
-                          uint64_t * prn_seeds, int stream)
+                          uint64_t* prn_seeds, int stream)
 {
   // Sample the outgoing energy using the base-class method
   int i_gout;
@@ -537,7 +537,7 @@ ScattDataHistogram::calc_f(int gin, int gout, double mu)
 
 void
 ScattDataHistogram::sample(int gin, int& gout, double& mu, double& wgt,
-                           uint64_t * prn_seeds, int stream)
+                           uint64_t* prn_seeds, int stream)
 {
   // Sample the outgoing energy using the base-class method
   int i_gout;
@@ -741,7 +741,7 @@ ScattDataTabular::calc_f(int gin, int gout, double mu)
 
 void
 ScattDataTabular::sample(int gin, int& gout, double& mu, double& wgt,
-                         uint64_t * prn_seeds, int stream)
+                         uint64_t* prn_seeds, int stream)
 {
   // Sample the outgoing energy using the base-class method
   int i_gout;

--- a/src/secondary_correlated.cpp
+++ b/src/secondary_correlated.cpp
@@ -153,7 +153,7 @@ CorrelatedAngleEnergy::CorrelatedAngleEnergy(hid_t group)
 }
 
 void CorrelatedAngleEnergy::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
   // Before the secondary distribution refactor, an isotropic polar cosine was

--- a/src/secondary_kalbach.cpp
+++ b/src/secondary_kalbach.cpp
@@ -113,7 +113,7 @@ KalbachMann::KalbachMann(hid_t group)
   } // incoming energies
 }
 
-void KalbachMann::sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds, int stream) const
+void KalbachMann::sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds, int stream) const
 {
   // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< REMOVE THIS <<<<<<<<<<<<<<<<<<<<<<<<<<<<<
   // Before the secondary distribution refactor, an isotropic polar cosine was

--- a/src/secondary_nbody.cpp
+++ b/src/secondary_nbody.cpp
@@ -22,7 +22,7 @@ NBodyPhaseSpace::NBodyPhaseSpace(hid_t group)
 }
 
 void NBodyPhaseSpace::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // By definition, the distribution of the angle is isotropic for an N-body
   // phase space distribution

--- a/src/secondary_thermal.cpp
+++ b/src/secondary_thermal.cpp
@@ -32,7 +32,7 @@ CoherentElasticAE::CoherentElasticAE(const CoherentElasticXS& xs)
 { }
 
 void
-CoherentElasticAE::sample(double E_in, double& E_out, double& mu, uint64_t * prn_seeds,
+CoherentElasticAE::sample(double E_in, double& E_out, double& mu, uint64_t* prn_seeds,
   int stream) const
 {
   // Get index and interpolation factor for elastic grid
@@ -67,7 +67,7 @@ IncoherentElasticAE::IncoherentElasticAE(hid_t group)
 
 void
 IncoherentElasticAE::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // Sample angle by inverting the distribution in ENDF-102, Eq. 7.4
   double c = 2 * E_in * debye_waller_;
@@ -90,7 +90,7 @@ IncoherentElasticAEDiscrete::IncoherentElasticAEDiscrete(hid_t group,
 
 void
 IncoherentElasticAEDiscrete::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // Get index and interpolation factor for elastic grid
   int i;
@@ -129,7 +129,7 @@ IncoherentInelasticAEDiscrete::IncoherentInelasticAEDiscrete(hid_t group,
 
 void
 IncoherentInelasticAEDiscrete::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // Get index and interpolation factor for inelastic grid
   int i;
@@ -233,7 +233,7 @@ IncoherentInelasticAE::IncoherentInelasticAE(hid_t group)
 
 void
 IncoherentInelasticAE::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // Get index and interpolation factor for inelastic grid
   int i;

--- a/src/secondary_uncorrelated.cpp
+++ b/src/secondary_uncorrelated.cpp
@@ -53,7 +53,7 @@ UncorrelatedAngleEnergy::UncorrelatedAngleEnergy(hid_t group)
 
 void
 UncorrelatedAngleEnergy::sample(double E_in, double& E_out, double& mu,
-  uint64_t * prn_seeds, int stream) const
+  uint64_t* prn_seeds, int stream) const
 {
   // Sample cosine of scattering angle
   if (fission_) {

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -142,7 +142,7 @@ SourceDistribution::SourceDistribution(pugi::xml_node node)
 }
 
 
-Particle::Bank SourceDistribution::sample(uint64_t * prn_seeds, int stream) const
+Particle::Bank SourceDistribution::sample(uint64_t* prn_seeds, int stream) const
 {
   Particle::Bank site;
 
@@ -288,7 +288,7 @@ void initialize_source()
   }
 }
 
-Particle::Bank sample_external_source(uint64_t * prn_seeds)
+Particle::Bank sample_external_source(uint64_t* prn_seeds)
 {
   // Set the random number generator to the source stream.
   int stream = STREAM_SOURCE;

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -197,24 +197,24 @@ Surface::reflect(Position r, Direction u) const
 }
 
 Direction
-Surface::diffuse_reflect(Position r, Direction u, uint64_t * prn_seeds, int stream) const
+Surface::diffuse_reflect(Position r, Direction u, uint64_t* prn_seeds, int stream) const
 {
   // Diffuse reflect direction according to the normal.
-  // cosine distribution 
-  
+  // cosine distribution
+
   Direction n = this->normal(r);
   n /= n.norm();
   const double projection = n.dot(u);
-  
-  // sample from inverse function, u=sqrt(rand) since p(u)=2u, so F(u)=u^2 
-  const double mu = (projection>=0.0) ? 
-                  -std::sqrt(prn(prn_seeds, stream)) : std::sqrt(prn(prn_seeds, stream));  
-  
-  // sample azimuthal distribution uniformly 
+
+  // sample from inverse function, u=sqrt(rand) since p(u)=2u, so F(u)=u^2
+  const double mu = (projection>=0.0) ?
+                  -std::sqrt(prn(prn_seeds, stream)) : std::sqrt(prn(prn_seeds, stream));
+
+  // sample azimuthal distribution uniformly
   u = rotate_angle(n, mu, nullptr, prn_seeds, stream);
-  
-  // normalize the direction 
-  return u/u.norm();    
+
+  // normalize the direction
+  return u/u.norm();
 }
 
 CSGSurface::CSGSurface() : Surface{} {};

--- a/src/thermal.cpp
+++ b/src/thermal.cpp
@@ -151,7 +151,7 @@ ThermalScattering::ThermalScattering(hid_t group, const std::vector<double>& tem
 void
 ThermalScattering::calculate_xs(double E, double sqrtkT, int* i_temp,
                                 double* elastic, double* inelastic,
-                                uint64_t * prn_seeds, int stream) const
+                                uint64_t* prn_seeds, int stream) const
 {
   // Determine temperature for S(a,b) table
   double kT = sqrtkT*sqrtkT;
@@ -266,7 +266,7 @@ ThermalData::calculate_xs(double E, double* elastic, double* inelastic) const
 
 void
 ThermalData::sample(const NuclideMicroXS& micro_xs, double E,
-                    double* E_out, double* mu, uint64_t * prn_seeds, int stream)
+                    double* E_out, double* mu, uint64_t* prn_seeds, int stream)
 {
   // Determine whether inelastic or elastic scattering will occur
   if (prn(prn_seeds, stream) < micro_xs.thermal_elastic / micro_xs.thermal) {


### PR DESCRIPTION
I was going to make this comment on your PR, but since it was so pervasive I thought it would be easier to just do a global search-and-replace and then send a PR to your branch. Our [style guide](https://docs.openmc.org/en/latest/devguide/styleguide.html#naming) says that pointers/references should be attached to the type.